### PR TITLE
Force Network Connectivity tests to use an array

### DIFF
--- a/Intune.xml
+++ b/Intune.xml
@@ -794,7 +794,8 @@ netsh int ipv4 show neighbors
 
 	</Command>
 	<Command Type="PS" Team="Networking" OutputFileName="Connectivity_tests">
-$uniqueURLs = (dsregcmd /status) | ForEach-Object { if ($_ -match ".*https://(\w+.+?)\/") { $matches[1]} } | Get-Unique
+$uniqueURLs = @()
+$uniqueURLs += (dsregcmd /status) | ForEach-Object { if ($_ -match ".*https://(\w+.+?)\/") { $matches[1]} } | Get-Unique
 $uniqueURLs += "r.manage.microsoft.com"
 $uniqueURLs += "r.manage.microsoft.us"
 $uniqueURLs += "enterpriseregistration.windows.net"


### PR DESCRIPTION
So this is a funny bug I've stumbled upon. In some environments, the $uniqueURLs was defined as a string instead of an array, leading this unexpected results.

The value was initialized using the results of dsregcmd. In some scenarios, such as a device not being registered/joined to any domain, it would only contain one value "www.microsoft.com", and because of that, Powershell would return that as a string, instead of an array.
This led to the following lines to concatenate a string before doing network connectivity tests. Resulting in this wonderful result: 

_Error connecting to www.microsoft.comr.manage.microsoft.comr.manage.microsoft.usenterpriseregistration.windows.net: Exception calling "Wait" with "1" argument(s): "One or more errors occurred."
Able to connect to port 443 on www.microsoft.comr.manage.microsoft.comr.manage.microsoft.usenterpriseregistration.windows.net :  False_

That is an hilariously long URL that doesn't exist.

This changes force the variable to be initialized as an array THEN proceeds to add the dsregcmd values and other URLs to the mix.