### PR TITLE
Dynamically collect all MdmDiagnosticsTool areas from registry (fixes #16)

### DIFF
--- a/Intune.xml
+++ b/Intune.xml
@@ -2755,10 +2755,28 @@ while ( ($elapsed -lt $timeoutInSec) -and $stillRunning ) {
         $stillRunning = $false
     }
 }</Command>
-      <Command Type="PS" Team="General" OutputFileName="NA">MdmDiagnosticsTool.exe  -out $pwd
-$outputPath = "$env:temp\CollectedData\Intune\Commands\General"
+      <Command Type="PS" Team="General" OutputFileName="NA">$outputPath = "$env:temp\CollectedData\Intune\Commands\General"
 $x = if (-not (Test-Path $outputPath)) { mkdir $outputPath -Force}
-move .\MDMDiagReport.* $outputPath</Command>
+
+# Dynamically read all available MdmDiagnostics areas from the registry
+$areaRegPath = "HKLM:\SOFTWARE\Microsoft\MdmDiagnostics\Area"
+if (Test-Path $areaRegPath) {
+    $areas = (Get-ChildItem $areaRegPath | Select-Object -ExpandProperty PSChildName) -join ";"
+    if ($areas) {
+        Write-Output "Running MdmDiagnosticsTool with areas: $areas"
+        MdmDiagnosticsTool.exe -area "$areas" -zip "$outputPath\MDMDiagReport-AllAreas.zip"
+    }
+    else {
+        Write-Output "No areas found under $areaRegPath, running default collection"
+        MdmDiagnosticsTool.exe -out $pwd
+        move .\MDMDiagReport.* $outputPath
+    }
+}
+else {
+    Write-Output "Registry key $areaRegPath not found, running default collection"
+    MdmDiagnosticsTool.exe -out $pwd
+    move .\MDMDiagReport.* $outputPath
+}</Command>
       <Command Type="PS" Team="General" OutputFileName="Windows_AV_(WATP)_info.txt">RunCommand -cmdToRun "Get-CimInstance -ClassName AntiVirusProduct            -Namespace  ROOT\SecurityCenter2"
 RunCommand -cmdToRun "Get-CimInstance -ClassName AntiSpywareProduct          -Namespace  ROOT\SecurityCenter2"
 RunCommand -cmdToRun "Get-CimInstance -ClassName FirewallProduct             -Namespace  ROOT\SecurityCenter2"

--- a/IntuneODCStandAlone.ps1
+++ b/IntuneODCStandAlone.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
     Stand-alone implementation of One Data Collector
 
 #>
@@ -40,7 +40,7 @@ $CompressedResultFileName = "$($env:COMPUTERNAME)_CollectedData_$fileTime.ZIP"
 [System.Nullable[bool]] $newZipperAvailable = $null # Stores flag whether [System.IO.Compression.ZipFile] can be used.
 
 $global:LogName = "$env:systemroot\temp\stdout.log"
-$ODCversion = "2026.2.15" 
+$ODCversion = "2026.3.23" 
 
 #endregion
 


### PR DESCRIPTION
## Summary
Fixes #16 - Expand parameters for MDMDIAGNOSTICSTOOL.EXE

## Changes
Replaced the static `MdmDiagnosticsTool.exe -out $pwd` command with dynamic registry-based area collection that:

1. Reads all available diagnostic areas from `HKLM:\SOFTWARE\Microsoft\MdmDiagnostics\Area`  
2. Joins them into a semicolon-delimited string (e.g., `Autopilot;DeviceEnrollment;DeviceProvisioning;OsConfiguration;TPM`)
3. Runs `MdmDiagnosticsTool.exe -area "<all areas>" -zip` to produce a comprehensive `MDMDiagReport-AllAreas.zip`  
4. Falls back to the original behavior if the registry key doesn't exist or has no areas

## Why
Previously, ODC only ran the default `MdmDiagnosticsTool.exe -out` which missed areas like **TPM** and **DeviceProvisioningService**. Support engineers had to manually run additional cab collections. This change automatically discovers and includes all registered areas.

## Testing
- Verified registry key `HKLM:\SOFTWARE\Microsoft\MdmDiagnostics\Area` returns 5 areas: Autopilot, DeviceEnrollment, DeviceProvisioning, OsConfiguration, TPM
- Unit tested: produced 18.5MB `MDMDiagReport-AllAreas.zip` with all areas
- Full end-to-end ODC test: zero errors, both Autopilot-specific and AllAreas ZIPs created successfully
- Output location: `Commands\General\MDMDiagReport-AllAreas.zip`