### PR TITLE
Add run summary, Delivery Optimization diagnostics, and Settings Catalog policy state

### DIFF
--- a/Intune.xml
+++ b/Intune.xml
@@ -3987,6 +3987,12 @@ del .\*DiagnosticLogCSP_Collector*.etl
 </Command>
       <Command Type="PS" Team="Windows Update" OutputFileName="FeatureUpdateHolds">reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Appraiser\GWX"</Command>
       <Command Type="PS" Team="General" OutputFileName="Get-DeliveryOptimizationLog">Get-DeliveryOptimizationLog</Command>
+      <Command Type="PS" Team="General" OutputFileName="DeliveryOptimization_Status.txt">RunCommand "Get-DeliveryOptimizationStatus"
+RunCommand "Get-DeliveryOptimizationPerfSnap"
+RunCommand "Get-DeliveryOptimizationPerfSnapThisMonth"
+RunCommand "Get-DOConfig -Verbose"
+RunCommand "Get-DOPercentageMaxBackgroundBandwidth"
+RunCommand "Get-DOPercentageMaxForegroundBandwidth"</Command>
       <Command Type="PS" Team="Windows Update" OutputFileName="ServiceManager_services">$ServiceManager = New-Object -ComObject "Microsoft.Update.ServiceManager"
 echo "`$ServiceManager = New-Object -ComObject Microsoft.Update.ServiceManager;`$ServiceManager.services| fl *"
 echo $("*" * 60)
@@ -5253,6 +5259,7 @@ $resultBlob | Format-List
       <EventLog Team="..\EventLogs">%SystemRoot%\system32\winevt\logs\*appx*</EventLog>
       <EventLog Team="..\EventLogs">%SystemRoot%\system32\winevt\logs\*bitlocker*</EventLog>
       <EventLog Team="..\EventLogs">%SystemRoot%\system32\winevt\logs\*defender*</EventLog>
+      <EventLog Team="..\EventLogs">%SystemRoot%\system32\winevt\logs\*DeliveryOptimization*</EventLog>
       <EventLog Team="..\EventLogs">%SystemRoot%\system32\winevt\logs\*devicemanagement*</EventLog>
       <EventLog Team="..\EventLogs">%SystemRoot%\system32\winevt\logs\*firewall*</EventLog>
       <EventLog Team="..\EventLogs">%SystemRoot%\system32\winevt\logs\*intune*</EventLog>
@@ -5365,7 +5372,11 @@ $resultBlob | Format-List
 	
 <Registries> 
       <Registry Team="..\Commands\Windows Update" OutputFileName="REG_SW_Microsoft_CloudManagedUpdate">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\CloudManagedUpdate</Registry>	  
-      <Registry Team="..\Commands\Windows Update" OutputFileName="REG_SW_Microsoft_PolicyManager_Current_Device_Update">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PolicyManager\current\device\Update</Registry> 
+      <Registry Team="..\Commands\Windows Update" OutputFileName="REG_SW_Microsoft_PolicyManager_Current_Device_Update">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PolicyManager\current\device\Update</Registry>
+      <Registry Team="..\RegistryKeys" OutputFileName="REG_SW_Microsoft_PolicyManager_Current">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PolicyManager\current</Registry>
+      <Registry Team="..\RegistryKeys" OutputFileName="REG_SW_Microsoft_PolicyManager_Providers">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PolicyManager\providers</Registry>
+      <Registry Team="..\RegistryKeys" OutputFileName="REG_SW_Microsoft_PolicyManager_AdmxInstalled">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PolicyManager\AdmxInstalled</Registry>
+      <Registry Team="..\RegistryKeys" OutputFileName="REG_SW_Microsoft_PolicyManager_AdmxDefault">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PolicyManager\AdmxDefault</Registry> 
       <Registry Team="..\Commands\Windows Update" OutputFileName="REG_SW_Microsoft_WindowsUpdate">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WindowsUpdate</Registry>
       <Registry Team="..\Commands\Windows Update" OutputFileName="REG_SW_Microsoft_Windows_CV_WindowsUpdate">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate</Registry>
       <Registry Team="..\Commands\Windows Update" OutputFileName="REG_SW_Microsoft_WufbDS">HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WufbDS</Registry>	

--- a/IntuneODCStandAlone.ps1
+++ b/IntuneODCStandAlone.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
     Stand-alone implementation of One Data Collector
 
 #>
@@ -40,7 +40,8 @@ $CompressedResultFileName = "$($env:COMPUTERNAME)_CollectedData_$fileTime.ZIP"
 [System.Nullable[bool]] $newZipperAvailable = $null # Stores flag whether [System.IO.Compression.ZipFile] can be used.
 
 $global:LogName = "$env:systemroot\temp\stdout.log"
-$ODCversion = "2026.3.23" 
+$ODCversion = "2026.4.24"
+$Global:ScriptStartTime = Get-Date
 
 #endregion
 
@@ -1702,10 +1703,115 @@ function Process-Package
     }
 }
 
+function Write-RunSummary {
+    <#
+    .SYNOPSIS
+    Generates a _SUMMARY.txt at the root of the collected data folder so engineers
+    triaging the ZIP can immediately see run metadata and key health indicators.
+    #>
+    if (-not (Test-Path $ResultRootDirectory)) { return }
+
+    $summaryPath = Join-Path $ResultRootDirectory '_SUMMARY.txt'
+    $endTime = Get-Date
+    $duration = $endTime - $Global:ScriptStartTime
+
+    $sb = New-Object System.Text.StringBuilder
+    [void]$sb.AppendLine(('=' * 80))
+    [void]$sb.AppendLine("  Intune One Data Collector (ODC) - Run Summary")
+    [void]$sb.AppendLine(('=' * 80))
+    [void]$sb.AppendLine("ODC Version       : $ODCversion")
+    [void]$sb.AppendLine("Computer Name     : $env:COMPUTERNAME")
+    [void]$sb.AppendLine("User              : $env:USERDOMAIN\$env:USERNAME")
+    [void]$sb.AppendLine("Run Start (Local) : $($Global:ScriptStartTime.ToString('yyyy-MM-dd HH:mm:ss zzz'))")
+    [void]$sb.AppendLine("Run End   (Local) : $($endTime.ToString('yyyy-MM-dd HH:mm:ss zzz'))")
+    [void]$sb.AppendLine("Duration          : {0:c}" -f $duration)
+
+    try {
+        $os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
+        [void]$sb.AppendLine("OS                : $($os.Caption) (Build $($os.BuildNumber))")
+    } catch { [void]$sb.AppendLine("OS                : (unable to query)") }
+
+    # Folder size + file count
+    try {
+        $items = Get-ChildItem -Path $ResultRootDirectory -Recurse -File -ErrorAction SilentlyContinue
+        $totalBytes = ($items | Measure-Object -Property Length -Sum).Sum
+        [void]$sb.AppendLine("Files Collected   : $($items.Count)")
+        [void]$sb.AppendLine("Total Size        : {0:N2} MB" -f ($totalBytes / 1MB))
+    } catch {}
+
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine(('-' * 80))
+    [void]$sb.AppendLine("  Key Health Indicators")
+    [void]$sb.AppendLine(('-' * 80))
+
+    # Azure AD / MDM enrollment state
+    try {
+        $ds = dsregcmd /status 2>$null
+        $aadJoined  = if ($ds -match 'AzureAdJoined\s*:\s*YES') { 'YES' } else { 'NO' }
+        $domJoined  = if ($ds -match 'DomainJoined\s*:\s*YES')  { 'YES' } else { 'NO' }
+        $workplace  = if ($ds -match 'WorkplaceJoined\s*:\s*YES') { 'YES' } else { 'NO' }
+        [void]$sb.AppendLine("AzureAdJoined     : $aadJoined")
+        [void]$sb.AppendLine("DomainJoined      : $domJoined")
+        [void]$sb.AppendLine("WorkplaceJoined   : $workplace")
+    } catch { [void]$sb.AppendLine("dsregcmd          : (failed to run)") }
+
+    # IME service state
+    try {
+        $ime = Get-Service -Name IntuneManagementExtension -ErrorAction Stop
+        $marker = if ($ime.Status -ne 'Running') { ' [!]' } else { '' }
+        [void]$sb.AppendLine("IME Service       : $($ime.Status) (StartType: $($ime.StartType))$marker")
+    } catch { [void]$sb.AppendLine("IME Service       : NOT INSTALLED [!]") }
+
+    # MDM enrollment cert
+    try {
+        $cert = Get-ChildItem Cert:\LocalMachine\My -ErrorAction SilentlyContinue |
+                Where-Object { $_.Issuer -match 'CN=Microsoft Intune MDM Device CA' } |
+                Sort-Object NotAfter -Descending | Select-Object -First 1
+        if ($cert) {
+            $daysLeft = ($cert.NotAfter - (Get-Date)).Days
+            $marker = if ($daysLeft -lt 30) { ' [!]' } else { '' }
+            [void]$sb.AppendLine("MDM Cert Expires  : $($cert.NotAfter.ToString('yyyy-MM-dd')) ($daysLeft days)$marker")
+        } else {
+            [void]$sb.AppendLine("MDM Cert          : NOT FOUND")
+        }
+    } catch {}
+
+    # Disk space on system drive
+    try {
+        $drive = Get-PSDrive -Name ($env:SystemDrive.TrimEnd(':')) -ErrorAction Stop
+        $freeGB = [math]::Round($drive.Free / 1GB, 1)
+        $marker = if ($freeGB -lt 5) { ' [!]' } else { '' }
+        [void]$sb.AppendLine("Free Space ($($env:SystemDrive)) : $freeGB GB$marker")
+    } catch {}
+
+    # Errors observed in the ODC log itself
+    try {
+        if (Test-Path $global:LogName) {
+            $errCount = (Get-Content $global:LogName -ErrorAction SilentlyContinue |
+                         Select-String -Pattern '\bError\b|\bException\b|\bFailed\b' -CaseSensitive:$false |
+                         Where-Object { $_ -notmatch 'SilentlyContinue|ErrorAction|ErrorVariable|ErrorActionPreference|FullyQualifiedErrorId|No errors' }).Count
+            $marker = if ($errCount -gt 0) { ' [!]' } else { '' }
+            [void]$sb.AppendLine("ODC Log Errors    : $errCount$marker")
+        }
+    } catch {}
+
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine('Items flagged with [!] may warrant investigation.')
+    [void]$sb.AppendLine(('=' * 80))
+
+    try {
+        Set-Content -Path $summaryPath -Value $sb.ToString() -Encoding UTF8 -Force
+        Write-Log -Message "Run summary written to $summaryPath" -Level Information
+    } catch {
+        Write-Log -Message "Failed to write run summary: $_" -Level Warning
+    }
+}
+
 function Compress-CollectedDataAndReport
 {
     if(Test-Path($ResultRootDirectory))
     {
+        Write-RunSummary
         Write-DiagProgress -Activity "Compressing zip file" -status $CompressedResultFileName
         
         


### PR DESCRIPTION
## Summary
Three improvements to make ODC ZIPs faster to triage and to fill diagnostic gaps for common Intune support cases.

## Changes

### 1. Run summary (`_SUMMARY.txt`) at root of collected data
New `Write-RunSummary` function in `IntuneODCStandAlone.ps1` writes a one-page summary at the root of the ZIP so engineers see device state at a glance:
- ODC version, run duration, OS, file count, total size
- Health indicators: AAD/Domain/Workplace join, IME service status, MDM cert expiry, free disk space, ODC log error count
- Items flagged with `[!]` for quick triage (e.g., IME stopped, cert expiring within 30 days, free space < 5 GB)

### 2. Delivery Optimization diagnostics (Intune.xml)
For diagnosing Win32 app / update download issues:
- `Get-DeliveryOptimizationStatus`, `Get-DeliveryOptimizationPerfSnap`, `...ThisMonth`
- `Get-DOConfig -Verbose`, `Get-DOPercentageMaxBackgroundBandwidth`, `Get-DOPercentageMaxForegroundBandwidth`
- `Microsoft-Windows-DeliveryOptimization*` event log capture

### 3. Settings Catalog / Policy CSP state (Intune.xml)
Full export of effective policy state:
- `HKLM\SOFTWARE\Microsoft\PolicyManager\current` (effective policy values)
- `HKLM\SOFTWARE\Microsoft\PolicyManager\providers` (per-provider ownership)
- `HKLM\SOFTWARE\Microsoft\PolicyManager\AdmxInstalled` (Settings Catalog ADMX-backed policies)
- `HKLM\SOFTWARE\Microsoft\PolicyManager\AdmxDefault` (defaults for comparison)

## Why
- **Run summary** dramatically reduces triage time — engineers no longer need to dig through dozens of files just to confirm basic device state
- **Delivery Optimization** data is critical for Win32 app deployment failures (peering, bandwidth caps, DO group ID issues)
- **Settings Catalog policy state** lets engineers see exactly what policies were applied and from which source — currently only the legacy `PolicyManager\current\device` subset is captured
