### PR TITLE
Capture HKLM\SOFTWARE\Microsoft\Policies (PassportForWork, LAPS CSP config)

### DIFF
--- a/Intune.xml
+++ b/Intune.xml
@@ -2573,6 +2573,16 @@ else {
 		"Warning - no policies found under HKLM:\Software\Microsoft\PolicyManager\current\device"
 		}
 		</Command>
+      <Command Type="PS" Team="General" OutputFileName="Policies_CSP_Registry">
+      # Capture CSP-applied configuration stored under HKLM\SOFTWARE\Microsoft\Policies
+      # CSPs such as PassportForWork (Windows Hello for Business) and LAPS write their resolved settings here.
+      if (test-path HKLM:\SOFTWARE\Microsoft\Policies) {
+		reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Policies /s 
+		}
+		else {
+		"Warning - no policies found under HKLM:\Software\Microsoft\Policies"
+		}
+		</Command>
       <Command Type="PS" Team="NDES" OutputFileName="localmachine_cert_info">if ( (dir Cert:\LocalMachine\My).Count -gt 0) {
 
     dir Cert:\LocalMachine\My | Select-Object * -ExpandProperty Extensions -ExcludeProperty RawData, PrivateKey 


### PR DESCRIPTION
## Summary
Adds collection of the registry hive `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Policies` to the ODC dataset.

Several CSPs store their resolved/applied configuration under this path rather than under `PolicyManager`, including:
- PassportForWork (Windows Hello for Business)
- LAPS (Windows Local Administrator Password Solution)

Previously the collector captured `...\PolicyManager\current\device` and the IME `...\IntuneManagementExtension\Policies` keys, but not `...\Microsoft\Policies`, so this CSP state was missing from logs and made Account Protection / WHfB / LAPS troubleshooting harder.

## Change
- New command block (OutputFileName="Policies_CSP_Registry") added right after the existing MDM_Policies capture in Intune.xml.
- Recursively dumps the hive via `reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Policies /s`.
- Guarded with Test-Path; writes a warning if the key is absent (same defensive pattern as MDM_Policies).
- Read-only; no duplicate capture (no other command queries this path; output filename is unique).
